### PR TITLE
Add support for linter on Mac and Pylint with Conda environments on Mac 

### DIFF
--- a/delta/subcommands/classify.py
+++ b/delta/subcommands/classify.py
@@ -81,7 +81,7 @@ def classify_image(model, image, label, path, net_name, options):
 
     error_image = None
     if label:
-        error_image = writer('errors_' + base_name + '.tiff')
+        error_image = writer('errors_' + net_name + '_' + base_name + '.tiff')
         assert image.size() == label.size(), 'Image and label do not match.'
 
     ts = config.io.tile_size()
@@ -111,7 +111,7 @@ def classify_image(model, image, label, path, net_name, options):
         sys.exit(0)
 
     if options.autoencoder:
-        write_tiff('orig_' + base_name + '.tiff', image.read() if options.noColormap else ae_convert(image.read()),
+        write_tiff('orig_' + net_name + '_' + base_name + '.tiff', image.read() if options.noColormap else ae_convert(image.read()),
                    metadata=image.metadata())
 
     if label:
@@ -120,7 +120,7 @@ def classify_image(model, image, label, path, net_name, options):
         print_classes(cm)
         if len(config.dataset.classes) != cm.shape[0]:
             class_names = list(map(lambda x: 'Class %d' % (x), range(cm.shape[0])))
-        save_confusion(cm, class_names, 'confusion_' + base_name + '.pdf')
+        save_confusion(cm, class_names, 'confusion_' + net_name + '_' + base_name + '.pdf')
         return cm
     return None
 

--- a/delta/subcommands/classify.py
+++ b/delta/subcommands/classify.py
@@ -111,7 +111,8 @@ def classify_image(model, image, label, path, net_name, options):
         sys.exit(0)
 
     if options.autoencoder:
-        write_tiff('orig_' + net_name + '_' + base_name + '.tiff', image.read() if options.noColormap else ae_convert(image.read()),
+        write_tiff('orig_' + net_name + '_' + base_name + '.tiff',
+                   image.read() if options.noColormap else ae_convert(image.read()),
                    metadata=image.metadata())
 
     if label:

--- a/scripts/linter/pre-commit
+++ b/scripts/linter/pre-commit
@@ -1,9 +1,16 @@
 #!/bin/bash
 
 # only check files being committed (but not deleted files)
-git diff-index --cached HEAD --name-only --diff-filter=ACMRTUXB |
-grep '\.py$' |
-xargs --null --no-run-if-empty ./scripts/linter/lint;
+TO_BE_LINTED=$(git diff-index --cached HEAD --name-only --diff-filter=ACMRTUXB |
+grep '\.py$')
+
+# rewrote previous command to be cross platform compatible for linux and mac.
+# Mac xargs doesn't support -- options and doesn't support --no-run-if-empty at all with default libraries
+if [ ! -z "$TO_BE_LINTED" ]; then
+  echo $TO_BE_LINTED | xargs -0 ./scripts/linter/lint;
+else
+  echo "No files to lint."
+fi
 
 if [ "$?" != "0" ]; then
   echo "Linter failed."

--- a/scripts/linter/pylintrc
+++ b/scripts/linter/pylintrc
@@ -5,7 +5,8 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook='import sys; import os; sys.path.append(os.path.abspath("."))'
+# Manually added PYTHONPATH to sys.path because there's a bug with pylint and virtualenvs correctly inheriting PYTHONPATH
+init-hook='import sys; import os; sys.path.extend([os.path.abspath("."),*os.environ["PYTHONPATH"].split(":")])'
 
 # Profiled execution.
 profile=no


### PR DESCRIPTION
Fixes #83

pre-commit
- Mac xargs doesn't support -- options so implemented --no-run-if-empty as if logic and --null as -0

pylintrc
- there's a bug with pylint and virtualenvs possibly on Macs so manually added PYTHONPATH to sys.path in the init-hook