### PR TITLE
Update landsat.py

### DIFF
--- a/delta/extensions/sources/landsat.py
+++ b/delta/extensions/sources/landsat.py
@@ -43,7 +43,7 @@ def _parse_mtl_file(mtl_path):
                     'REFLECTANCE_MULT', 'REFLECTANCE_ADD',
                     'K1_CONSTANT', 'K2_CONSTANT']
 
-    data = dict()
+    data = {}
     with open(mtl_path, 'r') as f:
         for line in f:
             line = line.replace('"','') # Clean up
@@ -72,7 +72,7 @@ def _parse_mtl_file(mtl_path):
                         break
 
                     if tag not in data:
-                        data[tag] = dict()
+                        data[tag] = {}
                     if tag == 'FILE_NAME':
                         data[tag][band] = value # String
                     else:


### PR DESCRIPTION
#PERFORMANCE

**DESCRIPTION**
Using the literal syntax can give minor performance bumps compared to using function calls to create dict, list and tuple. This is because here, the name dict must be looked up in the global scope in case it has been rebound. Same goes for the other two types list() and tuple(). Thank you