### PR TITLE
Remove extraneous field 'model' from example yaml

### DIFF
--- a/delta/config/README.md
+++ b/delta/config/README.md
@@ -27,8 +27,7 @@ with training parameters given in `train.yaml`:
 ```yaml
 train:
   network:
-    model:
-      yaml_file: networks/convpool.yaml
+    yaml_file: networks/convpool.yaml
   epochs: 10
 ```
 

--- a/scripts/example/l8_cloud.yaml
+++ b/scripts/example/l8_cloud.yaml
@@ -38,105 +38,104 @@ train:
   metrics:
     - sparse_categorical_accuracy
   network:
-    model:
-      layers:
-       - Input:
-           shape: [~, ~, num_bands]
-       - Conv2D:
-            filters: 16
-            kernel_size: [3, 3]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: c1
-       - Dropout:
-           rate: 0.2
-       - MaxPool2D:
-       - Conv2D:
-            filters: 32
-            kernel_size: [3, 3]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: c2
-       - Dropout:
-           rate: 0.2
-       - MaxPool2D:
-       - Conv2D:
-            filters: 64
-            kernel_size: [3, 3]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: c3
-       - Dropout:
-           rate: 0.2
-       - MaxPool2D:
-       - Conv2D:
-            filters: 128
-            kernel_size: [3, 3]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: c4
-       - UpSampling2D:
-       - Conv2D:
-            filters: 64
-            kernel_size: [2, 2]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: u3
-       - Concatenate:
-           inputs: [c3, u3]
-       - Dropout:
-           rate: 0.2
-       - Conv2D:
-            filters: 64
-            kernel_size: [3, 3]
-            padding: same
-       - UpSampling2D:
-       - Conv2D:
-            filters: 32
-            kernel_size: [2, 2]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: u2
-       - Concatenate:
-           inputs: [c2, u2]
-       - Dropout:
-           rate: 0.2
-       - Conv2D:
-            filters: 32
-            kernel_size: [3, 3]
-            padding: same
-       - UpSampling2D:
-       - Conv2D:
-            filters: 16
-            kernel_size: [2, 2]
-            padding: same
-       - BatchNormalization:
-       - Activation:
-           activation: relu
-           name: u1
-       - Concatenate:
-           inputs: [c1, u1]
-       - Dropout:
-           rate: 0.2
-       - Conv2D:
-           filters: 7
+    layers:
+      - Input:
+          shape: [~, ~, num_bands]
+      - Conv2D:
+           filters: 16
            kernel_size: [3, 3]
-           activation: linear
            padding: same
-       - Softmax:
-           axis: 3
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: c1
+      - Dropout:
+          rate: 0.2
+      - MaxPool2D:
+      - Conv2D:
+           filters: 32
+           kernel_size: [3, 3]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: c2
+      - Dropout:
+          rate: 0.2
+      - MaxPool2D:
+      - Conv2D:
+           filters: 64
+           kernel_size: [3, 3]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: c3
+      - Dropout:
+          rate: 0.2
+      - MaxPool2D:
+      - Conv2D:
+           filters: 128
+           kernel_size: [3, 3]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: c4
+      - UpSampling2D:
+      - Conv2D:
+           filters: 64
+           kernel_size: [2, 2]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: u3
+      - Concatenate:
+          inputs: [c3, u3]
+      - Dropout:
+          rate: 0.2
+      - Conv2D:
+           filters: 64
+           kernel_size: [3, 3]
+           padding: same
+      - UpSampling2D:
+      - Conv2D:
+           filters: 32
+           kernel_size: [2, 2]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: u2
+      - Concatenate:
+          inputs: [c2, u2]
+      - Dropout:
+          rate: 0.2
+      - Conv2D:
+           filters: 32
+           kernel_size: [3, 3]
+           padding: same
+      - UpSampling2D:
+      - Conv2D:
+           filters: 16
+           kernel_size: [2, 2]
+           padding: same
+      - BatchNormalization:
+      - Activation:
+          activation: relu
+          name: u1
+      - Concatenate:
+          inputs: [c1, u1]
+      - Dropout:
+          rate: 0.2
+      - Conv2D:
+          filters: 7
+          kernel_size: [3, 3]
+          activation: linear
+          padding: same
+      - Softmax:
+          axis: 3
   batch_size: 10
   epochs: 10
   validation:


### PR DESCRIPTION
Attempting to run the Landsat-8 example script (`./scripts/example/l8_cloud.sh') results in a Python error `ValueError: Unexpected field model in config file.`

The field 'model' seemed to be extraneous, so I removed it from the config file entirely (along with from its README). That's all.

Thanks for the great framework!