### PR TITLE
Added epsilon to denominator of dice_coef function to prevent nans

### DIFF
--- a/delta/extensions/losses.py
+++ b/delta/extensions/losses.py
@@ -48,7 +48,9 @@ def dice_coef(y_true, y_pred, smooth=1):
     ref: https://arxiv.org/pdf/1606.04797v1.pdf
     """
     intersection = K.sum(K.abs(y_true * y_pred), axis=-1)
-    return (2. * intersection + smooth) / (K.sum(K.square(y_true),-1) + K.sum(K.square(y_pred),-1) + smooth)
+    return (2. * intersection + smooth) / (
+            K.sum(K.square(y_true),-1) +
+            K.sum(K.square(y_pred),-1) + smooth + K.epsilon())
 
 def dice_loss(y_true, y_pred):
     """

--- a/delta/extensions/losses.py
+++ b/delta/extensions/losses.py
@@ -49,8 +49,7 @@ def dice_coef(y_true, y_pred, smooth=1):
     """
     intersection = K.sum(K.abs(y_true * y_pred), axis=-1)
     return (2. * intersection + smooth) / (
-            K.sum(K.square(y_true),-1) +
-            K.sum(K.square(y_pred),-1) + smooth + K.epsilon())
+                K.sum(K.square(y_true), -1) + K.sum(K.square(y_pred), -1) + smooth + K.epsilon())
 
 def dice_loss(y_true, y_pred):
     """


### PR DESCRIPTION
This may fix the cause of the nans. I added K.epsilon to the denominator of the dice loss function. It's common to prevent losses from nan-ing if their denominator is 0.