### PR TITLE
Classify fixes

### DIFF
--- a/delta/config/README.md
+++ b/delta/config/README.md
@@ -144,9 +144,10 @@ Classify
 -----
 These options are used in the `delta classify` command.
 
+ * `prob_image`: If true, save an image with the network outputs as probabilities. Otherwise, map to the most likely class.
+ * `overlap`: If set, apply an overlap to the tiles during classification.
  * `regions`: A list of region names to look for in WKT files associated with images.
  * `wkt_dir`: Directory to look for WKT files in.  If not specified they are expected to be in the same folders as input images.
- * `results_file`: Write a copy of the output statistics to this file
  * `metrics`: Include either losses or metrics here as specified in the Train section.
 
 ```Sample config entries:
@@ -155,7 +156,6 @@ classify:
    - sample_region_name
    - another_region
   wkt_dir: /alternate/wkt/location/
-  results_file: log_here.txt
   metrics: # 2D metrics such as msssim are not supported
     - SparseRecall:
         label: No Water

--- a/delta/config/delta.yaml
+++ b/delta/config/delta.yaml
@@ -103,6 +103,13 @@ train:
       file_list:   ~
       files:       ~
 
+classify:
+  prob_image: true
+  overlap: 0
+  regions: ~
+  metrics: ~
+  wkt_dir: ~
+
 mlflow:
   # default to ~/.local/share/delta/mlflow
   enabled:        true

--- a/delta/extensions/losses.py
+++ b/delta/extensions/losses.py
@@ -98,12 +98,6 @@ def dice_loss(y_true, y_pred):
     """
     return 1 - dice_coef(y_true, y_pred)
 
-def focal_loss(y_true, y_pred):
-    """
-    Focal loss.
-    """
-    return tfa.losses.sigmoid_focal_crossentropy(y_true, y_pred)
-
 # # Simple script which includes functions for calculating surface loss in keras
 # ## See the related discussion: https://github.com/LIVIAETS/boundary-loss/issues/14
 def _calc_dist_map(seg):
@@ -299,7 +293,7 @@ register_loss('ms_ssim', ms_ssim)
 register_loss('ms_ssim_mse', ms_ssim_mse)
 register_loss('dice', dice_loss)
 register_loss('surface', surface_loss)
-register_loss('focal', focal_loss)
+register_loss('focal', tfa.losses.SigmoidFocalCrossEntropy)
 register_loss('MappedCategoricalCrossentropy', MappedCategoricalCrossentropy)
 register_loss('MappedBinaryCrossentropy', MappedBinaryCrossentropy)
 register_loss('MappedDice', MappedDiceLoss)

--- a/delta/extensions/metrics.py
+++ b/delta/extensions/metrics.py
@@ -148,6 +148,7 @@ class SparseBinaryAccuracy(SparseMetric): # pragma: no cover
         false_negatives = tf.math.logical_and(tf.math.logical_not(right_class), tf.math.logical_not(right_class_pred))
         if self._nodata_id:
             valid = tf.math.not_equal(y_true, self._nodata_id)
+            true_positives = tf.math.logical_and(true_positives, valid)
             false_negatives = tf.math.logical_and(false_negatives, valid)
             total = tf.math.reduce_sum(tf.cast(valid, tf.float32))
         else:

--- a/delta/ml/ml_config.py
+++ b/delta/ml/ml_config.py
@@ -278,13 +278,17 @@ class ClassifyConfig(config.DeltaConfigComponent):
     """
     def __init__(self):
         super().__init__()
+        self.register_field('prob_image', bool, 'prob_image', None, 'Set true to save a probability image.')
+        self.register_field('overlap', int, 'overlap', None, 'Amount to overlap processed tiles.')
         self.register_field('regions', list, None, None,
                             'List of region tags to compute statistics over, default is all tags.')
         self.register_field('metrics', list, None, None, 'List of metrics to apply.')
         self.register_field('wkt_dir', str, None, None,
                             'Look for WKT files in this folder, default is look in the input image folder.')
-        self.register_field('results_file', str, None, None,
-                            'Also write statistics to this file.')
+
+        self.register_arg('prob_image', '--prob', action='store_const', const=True, type=None)
+        self.register_arg('prob_image', '--noprob', action='store_const', const=False, type=None)
+        self.register_arg('overlap', '--overlap')
 
     def regions(self):
         if 'regions' in self._config_dict:
@@ -294,11 +298,6 @@ class ClassifyConfig(config.DeltaConfigComponent):
     def wkt_dir(self):
         if 'wkt_dir' in self._config_dict:
             return self._config_dict['wkt_dir']
-        return None
-
-    def results_file(self):
-        if 'results_file' in self._config_dict:
-            return self._config_dict['results_file']
         return None
 
     def metrics(self):

--- a/delta/subcommands/commands.py
+++ b/delta/subcommands/commands.py
@@ -45,13 +45,11 @@ def main_visualize(options):
 
 def setup_classify(subparsers):
     sub = subparsers.add_parser('classify', help='Classify images given a model.')
-    config.setup_arg_parser(sub, ['general', 'io', 'dataset'])
+    config.setup_arg_parser(sub, ['general', 'io', 'dataset', 'classify'])
 
-    sub.add_argument('--prob', dest='prob', action='store_true', help='Save image of class probabilities.')
     sub.add_argument('--autoencoder', dest='autoencoder', action='store_true', help='Classify with the autoencoder.')
     sub.add_argument('--no-colormap', dest='noColormap', action='store_true',
                      help='Save raw classification values instead of colormapped values.')
-    sub.add_argument('--overlap', dest='overlap', type=int, default=0, help='Classify with the autoencoder.')
     sub.add_argument('--validation', dest='validation', help='Classify validation images instead.')
     sub.add_argument('--outdir', dest='outdir', type=str, help='Directory to save output to.')
     sub.add_argument('--basedir', dest='basedir', type=str, help='Preserve paths of files relative to this directory.')


### PR DESCRIPTION
* Add probability image and overlap to config files.
* Default is now to write probability image.
* Always write a results file with the name of the network _results.txt
* Fix classify metrics--- pass probabilities not nearest class.
* Fix running mean computation for metrics.
* Make prints a bit prettier.